### PR TITLE
feat(families): add GET /api/families/{familyId}/members endpoint

### DIFF
--- a/.ai/api-plan.md
+++ b/.ai/api-plan.md
@@ -253,6 +253,54 @@ Deletes a family and all associated data. Only admins can perform this action.
 
 ### 2.4. Family Members
 
+#### List Family Members
+
+**GET** `/api/families/{familyId}/members`
+
+Retrieves all members of a specific family. Returns a list of family members with their user profile information (full name, avatar URL), role within the family, and join date. This endpoint is useful when you only need member information without the full family details or children list.
+
+**Path Parameters:**
+
+- `familyId` (required): UUID of the family
+
+**Query Parameters:** None
+
+**Response (200 OK):**
+
+```json
+{
+  "members": [
+    {
+      "user_id": "uuid",
+      "full_name": "string | null",
+      "avatar_url": "string | null",
+      "role": "admin|member",
+      "joined_at": "ISO8601 timestamp"
+    }
+  ]
+}
+```
+
+**Response Details:**
+
+- Members are ordered by `joined_at` ascending (oldest members first)
+- `full_name` and `avatar_url` may be `null` if not set by the user
+- Each member includes their role (`admin` or `member`) and join timestamp
+
+**Error Responses:**
+
+- `401 Unauthorized`: Missing or invalid JWT token
+- `400 Bad Request`: Invalid `familyId` format (not a valid UUID)
+- `403 Forbidden`: User is not a member of the specified family
+- `404 Not Found`: Family with the given `familyId` does not exist
+
+**Use Cases:**
+
+- Displaying a member list in the UI
+- Checking family membership before performing operations
+- Building member selection dropdowns
+- Member management interfaces
+
 #### Remove Family Member
 
 **DELETE** `/api/families/{familyId}/members/{userId}`

--- a/src/pages/api/families/[familyId]/members.test.ts
+++ b/src/pages/api/families/[familyId]/members.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { APIContext } from "astro";
+import { GET } from "./members";
+import { InMemoryFamilyRepository } from "@/repositories/implementations/in-memory/InMemoryFamilyRepository";
+import { InMemoryChildRepository } from "@/repositories/implementations/in-memory/InMemoryChildRepository";
+import { InMemoryLogRepository } from "@/repositories/implementations/in-memory/InMemoryLogRepository";
+import { createInMemoryRepositories } from "@/repositories/factory";
+
+describe("GET /api/families/[familyId]/members", () => {
+  let familyRepo: InMemoryFamilyRepository;
+  let childRepo: InMemoryChildRepository;
+  let logRepo: InMemoryLogRepository;
+  let userId: string;
+  let familyId: string;
+  let otherUserId: string;
+
+  beforeEach(async () => {
+    const repos = createInMemoryRepositories();
+    familyRepo = repos.family as InMemoryFamilyRepository;
+    childRepo = repos.child as InMemoryChildRepository;
+    logRepo = repos.log as InMemoryLogRepository;
+
+    userId = "550e8400-e29b-41d4-a716-446655440001";
+    otherUserId = "550e8400-e29b-41d4-a716-446655440002";
+
+    const family = await familyRepo.create({ name: "The Smiths" });
+    familyId = family.id;
+    await familyRepo.addMember(familyId, userId, "admin");
+    familyRepo.setUser(userId, { full_name: "John Doe", avatar_url: "https://example.com/avatar.jpg" });
+  });
+
+  function createMockContext(params: { familyId?: string; userId?: string }): APIContext {
+    return {
+      params: { familyId: params.familyId ?? familyId },
+      locals: {
+        user: params.userId ? { id: params.userId, email: "test@example.com" } : undefined,
+        repositories: {
+          family: familyRepo,
+          child: childRepo,
+          log: logRepo,
+        },
+      },
+    } as unknown as APIContext;
+  }
+
+  it("should return 200 with members list for authenticated member", async () => {
+    const memberUserId = "550e8400-e29b-41d4-a716-446655440003";
+    await familyRepo.addMember(familyId, memberUserId, "member");
+    familyRepo.setUser(memberUserId, { full_name: "Jane Doe", avatar_url: null });
+
+    const context = createMockContext({ userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toHaveProperty("members");
+    expect(Array.isArray(data.members)).toBe(true);
+    expect(data.members.length).toBeGreaterThanOrEqual(1);
+    expect(data.members[0]).toHaveProperty("user_id");
+    expect(data.members[0]).toHaveProperty("full_name");
+    expect(data.members[0]).toHaveProperty("avatar_url");
+    expect(data.members[0]).toHaveProperty("role");
+    expect(data.members[0]).toHaveProperty("joined_at");
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    const context = createMockContext({ userId: undefined });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("unauthorized");
+  });
+
+  it("should return 403 when user is not a member", async () => {
+    const context = createMockContext({ userId: otherUserId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("forbidden");
+    expect(data.message).toContain("do not have access");
+  });
+
+  it("should return 400 when family ID is missing", async () => {
+    const context = {
+      params: {},
+      locals: {
+        user: { id: userId, email: "test@example.com" },
+        repositories: {
+          family: familyRepo,
+          child: childRepo,
+          log: logRepo,
+        },
+      },
+    } as unknown as APIContext;
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("validation");
+  });
+
+  it("should return 400 when family ID is invalid UUID", async () => {
+    const context = createMockContext({ familyId: "invalid-id", userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("validation");
+    expect(data.message).toContain("Invalid family ID format");
+  });
+
+  it("should return 404 when family does not exist", async () => {
+    const fakeId = "550e8400-e29b-41d4-a716-446655440000";
+    const context = createMockContext({ familyId: fakeId, userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("notfound");
+  });
+
+  it("should return empty members array when family has only one member", async () => {
+    const context = createMockContext({ userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0].user_id).toBe(userId);
+  });
+
+  it("should return members ordered by joined_at ascending", async () => {
+    const member1Id = "550e8400-e29b-41d4-a716-446655440004";
+    const member2Id = "550e8400-e29b-41d4-a716-446655440005";
+
+    await familyRepo.addMember(familyId, member1Id, "member");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await familyRepo.addMember(familyId, member2Id, "member");
+
+    familyRepo.setUser(member1Id, { full_name: "Member 1", avatar_url: null });
+    familyRepo.setUser(member2Id, { full_name: "Member 2", avatar_url: null });
+
+    const context = createMockContext({ userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.members.length).toBeGreaterThanOrEqual(3);
+
+    const joinedDates = data.members.map((m: { joined_at: string }) => new Date(m.joined_at).getTime());
+    const sortedDates = [...joinedDates].sort((a: number, b: number) => a - b);
+    expect(joinedDates).toEqual(sortedDates);
+  });
+
+  it("should include all required member fields in response", async () => {
+    const context = createMockContext({ userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.members.length).toBeGreaterThan(0);
+
+    const member = data.members[0];
+    expect(member).toHaveProperty("user_id");
+    expect(member).toHaveProperty("full_name");
+    expect(member).toHaveProperty("avatar_url");
+    expect(member).toHaveProperty("role");
+    expect(member).toHaveProperty("joined_at");
+    expect(["admin", "member"]).toContain(member.role);
+    expect(typeof member.joined_at).toBe("string");
+  });
+
+  it("should handle members with null full_name and avatar_url", async () => {
+    const memberUserId = "550e8400-e29b-41d4-a716-446655440006";
+    await familyRepo.addMember(familyId, memberUserId, "member");
+    familyRepo.setUser(memberUserId, { full_name: null, avatar_url: null });
+
+    const context = createMockContext({ userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const member = data.members.find((m: { user_id: string }) => m.user_id === memberUserId);
+    expect(member).toBeDefined();
+    if (member) {
+      expect(member.full_name).toBeNull();
+      expect(member.avatar_url).toBeNull();
+    }
+  });
+
+  it("should validate response schema", async () => {
+    const context = createMockContext({ userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toHaveProperty("members");
+    expect(Array.isArray(data.members)).toBe(true);
+
+    if (data.members.length > 0) {
+      const member = data.members[0];
+      expect(member.user_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+      expect(member.joined_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    }
+  });
+});

--- a/src/pages/api/families/[familyId]/members.ts
+++ b/src/pages/api/families/[familyId]/members.ts
@@ -1,0 +1,68 @@
+import type { APIContext } from "astro";
+import { FamilyService } from "@/services/FamilyService";
+import { mapResultToResponse } from "@/lib/http/responseMapper";
+import { requireAuth } from "@/lib/http/apiHelpers";
+import { ValidationError } from "@/domain/errors";
+import { err, ok } from "@/domain/result";
+import { uuidSchema, listFamilyMembersResponseSchema } from "@/types";
+
+export const prerender = false;
+
+export async function GET({ params, locals }: APIContext): Promise<Response> {
+  try {
+    const userId = requireAuth(locals);
+    if (userId instanceof Response) return userId;
+
+    const familyId = params.familyId;
+    if (!familyId) {
+      return mapResultToResponse(
+        err(new ValidationError("Family ID is required", { familyId: "required" }))
+      );
+    }
+
+    const uuidValidation = uuidSchema.safeParse(familyId);
+    if (!uuidValidation.success) {
+      return mapResultToResponse(
+        err(new ValidationError("Invalid family ID format", { familyId: "invalid_uuid" }))
+      );
+    }
+
+    const familyService = new FamilyService(
+      locals.repositories.family,
+      locals.repositories.child,
+      locals.repositories.log
+    );
+    const result = await familyService.getFamilyMembers(familyId, userId);
+
+    if (!result.success) {
+      return mapResultToResponse(result);
+    }
+
+    const responseData = { members: result.data };
+    const validation = listFamilyMembersResponseSchema.safeParse(responseData);
+    if (!validation.success) {
+      return mapResultToResponse(
+        err(
+          new ValidationError("Invalid response data", {
+            response: "Failed validation",
+          })
+        )
+      );
+    }
+
+    return mapResultToResponse(ok(responseData));
+  } catch (error) {
+    console.error("Unexpected error in GET /api/families/[familyId]/members:", error);
+    return new Response(
+      JSON.stringify({
+        error: "internal_error",
+        message: "An unexpected error occurred",
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+}
+

--- a/src/services/FamilyService.test.ts
+++ b/src/services/FamilyService.test.ts
@@ -309,4 +309,132 @@ describe("FamilyService", () => {
       expect(logs[0].family_id).toBe(familyId);
     });
   });
+
+  describe("getFamilyMembers", () => {
+    let familyId: string;
+
+    beforeEach(async () => {
+      const family = await familyRepo.create({ name: "The Smiths" });
+      familyId = family.id;
+      await familyRepo.addMember(familyId, userId, "admin");
+      familyRepo.setUser(userId, { full_name: "John Doe", avatar_url: "https://example.com/avatar.jpg" });
+    });
+
+    it("should return members when user is a member", async () => {
+      const memberUserId = "member-user-123";
+      await familyRepo.addMember(familyId, memberUserId, "member");
+      familyRepo.setUser(memberUserId, { full_name: "Jane Doe", avatar_url: null });
+
+      const result = await familyService.getFamilyMembers(familyId, userId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveLength(2);
+        expect(result.data[0].user_id).toBe(userId);
+        expect(result.data[0].full_name).toBe("John Doe");
+        expect(result.data[0].avatar_url).toBe("https://example.com/avatar.jpg");
+        expect(result.data[0].role).toBe("admin");
+        expect(result.data[1].user_id).toBe(memberUserId);
+        expect(result.data[1].full_name).toBe("Jane Doe");
+        expect(result.data[1].avatar_url).toBeNull();
+        expect(result.data[1].role).toBe("member");
+      }
+    });
+
+    it("should return empty array when family has no members", async () => {
+      const emptyFamily = await familyRepo.create({ name: "Empty Family" });
+      await familyRepo.addMember(emptyFamily.id, userId, "admin");
+
+      const result = await familyService.getFamilyMembers(emptyFamily.id, userId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveLength(1);
+        expect(result.data[0].user_id).toBe(userId);
+      }
+    });
+
+    it("should return error if family ID is invalid UUID", async () => {
+      const result = await familyService.getFamilyMembers("invalid-id", userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toContain("Invalid family ID format");
+      }
+    });
+
+    it("should return error if family not found", async () => {
+      const fakeId = "550e8400-e29b-41d4-a716-446655440000";
+      const result = await familyService.getFamilyMembers(fakeId, userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(NotFoundError);
+      }
+    });
+
+    it("should return error if user is not a member", async () => {
+      const otherUserId = "other-user-123";
+      const result = await familyService.getFamilyMembers(familyId, otherUserId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ForbiddenError);
+        expect(result.error.message).toContain("do not have access");
+      }
+    });
+
+    it("should return members ordered by joined_at ascending", async () => {
+      const member1Id = "member-1";
+      const member2Id = "member-2";
+
+      await familyRepo.addMember(familyId, member1Id, "member");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await familyRepo.addMember(familyId, member2Id, "member");
+
+      familyRepo.setUser(member1Id, { full_name: "Member 1", avatar_url: null });
+      familyRepo.setUser(member2Id, { full_name: "Member 2", avatar_url: null });
+
+      const result = await familyService.getFamilyMembers(familyId, userId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.length).toBeGreaterThanOrEqual(3);
+        const joinedDates = result.data.map((m) => new Date(m.joined_at).getTime());
+        const sortedDates = [...joinedDates].sort((a, b) => a - b);
+        expect(joinedDates).toEqual(sortedDates);
+      }
+    });
+
+    it("should log family.members.list action", async () => {
+      await familyService.getFamilyMembers(familyId, userId);
+
+      const logs = logRepo.getLogs();
+      expect(logs.length).toBe(1);
+      expect(logs[0].action).toBe("family.members.list");
+      expect(logs[0].actor_id).toBe(userId);
+      expect(logs[0].actor_type).toBe("user");
+      expect(logs[0].family_id).toBe(familyId);
+      expect(logs[0].details).toHaveProperty("member_count");
+    });
+
+    it("should handle members with null full_name and avatar_url", async () => {
+      const memberUserId = "member-user-123";
+      await familyRepo.addMember(familyId, memberUserId, "member");
+      familyRepo.setUser(memberUserId, { full_name: null, avatar_url: null });
+
+      const result = await familyService.getFamilyMembers(familyId, userId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const member = result.data.find((m) => m.user_id === memberUserId);
+        expect(member).toBeDefined();
+        if (member) {
+          expect(member.full_name).toBeNull();
+          expect(member.avatar_url).toBeNull();
+        }
+      }
+    });
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -294,6 +294,15 @@ export const familyMemberSchema = z.object({
 export type FamilyMemberDTO = z.infer<typeof familyMemberSchema>;
 
 /**
+ * Response: List family members
+ */
+export const listFamilyMembersResponseSchema = z.object({
+  members: z.array(familyMemberSchema),
+});
+
+export type ListFamilyMembersResponseDTO = z.infer<typeof listFamilyMembersResponseSchema>;
+
+/**
  * Child schema (forward reference for family details)
  */
 export const childSchema = z.object({


### PR DESCRIPTION
- Add listFamilyMembersResponseSchema to types.ts
- Implement getFamilyMembers method in FamilyService
- Create GET /api/families/[familyId]/members API route
- Add comprehensive unit tests for service method
- Add integration tests for API route
- Update API documentation with endpoint details
- Include audit logging for member list retrieval