### PR TITLE
feat(invitations): add family invitations API endpoint

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -6,6 +6,7 @@ import type {
   UserRepository,
   ChildRepository,
   LogRepository,
+  InvitationRepository,
 } from "./repositories/interfaces/index.ts";
 
 declare global {
@@ -17,6 +18,7 @@ declare global {
         user: UserRepository;
         child: ChildRepository;
         log: LogRepository;
+        invitation: InvitationRepository;
       };
       user: User | null;
     }

--- a/src/lib/utils/invitation.ts
+++ b/src/lib/utils/invitation.ts
@@ -1,0 +1,5 @@
+export function buildInvitationUrl(token: string): string {
+  const frontendUrl = import.meta.env.FRONTEND_URL || "http://localhost:4321";
+  return `${frontendUrl}/invitations/accept?token=${token}`;
+}
+

--- a/src/lib/utils/token.ts
+++ b/src/lib/utils/token.ts
@@ -1,0 +1,6 @@
+import { randomBytes } from "crypto";
+
+export function generateSecureToken(): string {
+  return randomBytes(32).toString("hex");
+}
+

--- a/src/pages/api/families/[familyId]/invitations/index.test.ts
+++ b/src/pages/api/families/[familyId]/invitations/index.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { APIContext } from "astro";
+import { GET, POST } from "./index";
+import { createInMemoryRepositories } from "@/repositories/factory";
+import { InMemoryFamilyRepository } from "@/repositories/implementations/in-memory/InMemoryFamilyRepository";
+import { InMemoryInvitationRepository } from "@/repositories/implementations/in-memory/InMemoryInvitationRepository";
+import { InMemoryUserRepository } from "@/repositories/implementations/in-memory/InMemoryUserRepository";
+import { InMemoryLogRepository } from "@/repositories/implementations/in-memory/InMemoryLogRepository";
+import type { InvitationEntity } from "@/types";
+
+describe("GET /api/families/[familyId]/invitations", () => {
+  let familyRepo: InMemoryFamilyRepository;
+  let invitationRepo: InMemoryInvitationRepository;
+  let userRepo: InMemoryUserRepository;
+  let logRepo: InMemoryLogRepository;
+  let userId: string;
+  let familyId: string;
+  let otherUserId: string;
+
+  beforeEach(async () => {
+    const repos = createInMemoryRepositories();
+    familyRepo = repos.family as InMemoryFamilyRepository;
+    invitationRepo = repos.invitation as InMemoryInvitationRepository;
+    userRepo = repos.user as InMemoryUserRepository;
+    logRepo = repos.log as InMemoryLogRepository;
+
+    userId = "550e8400-e29b-41d4-a716-446655440001";
+    otherUserId = "550e8400-e29b-41d4-a716-446655440002";
+
+    const family = await familyRepo.create({ name: "The Smiths" });
+    familyId = family.id;
+    await familyRepo.addMember(familyId, userId, "admin");
+
+    userRepo.seed({ id: userId, full_name: "John Doe", avatar_url: null, updated_at: null }, [], "john@example.com");
+  });
+
+  function createMockContext(params: { familyId?: string; userId?: string; status?: string }): APIContext {
+    const url = new URL("http://localhost/api/invitations");
+    if (params.status) {
+      url.searchParams.set("status", params.status);
+    }
+
+    return {
+      params: { familyId: params.familyId ?? familyId },
+      url,
+      locals: {
+        user: params.userId ? { id: params.userId, email: "test@example.com" } : undefined,
+        repositories: {
+          family: familyRepo,
+          invitation: invitationRepo,
+          user: userRepo,
+          log: logRepo,
+        },
+      },
+    } as unknown as APIContext;
+  }
+
+  it("should return 200 with invitations list for authenticated member", async () => {
+    const invitation1: InvitationEntity = {
+      id: crypto.randomUUID(),
+      family_id: familyId,
+      invited_by: userId,
+      invitee_email: "alice@example.com",
+      token: "token1",
+      status: "pending",
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      created_at: new Date().toISOString(),
+    };
+    invitationRepo.addInvitation(invitation1);
+
+    const context = createMockContext({ userId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toHaveProperty("invitations");
+    expect(Array.isArray(data.invitations)).toBe(true);
+    expect(data.invitations.length).toBe(1);
+    expect(data.invitations[0]).toHaveProperty("id");
+    expect(data.invitations[0]).toHaveProperty("family_id");
+    expect(data.invitations[0]).toHaveProperty("invitee_email");
+    expect(data.invitations[0]).toHaveProperty("status");
+    expect(data.invitations[0]).toHaveProperty("invited_by");
+    expect(data.invitations[0].invited_by).toHaveProperty("id");
+    expect(data.invitations[0].invited_by).toHaveProperty("full_name");
+  });
+
+  it("should filter invitations by status", async () => {
+    const pendingInvitation: InvitationEntity = {
+      id: crypto.randomUUID(),
+      family_id: familyId,
+      invited_by: userId,
+      invitee_email: "alice@example.com",
+      token: "token1",
+      status: "pending",
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      created_at: new Date().toISOString(),
+    };
+    const acceptedInvitation: InvitationEntity = {
+      id: crypto.randomUUID(),
+      family_id: familyId,
+      invited_by: userId,
+      invitee_email: "bob@example.com",
+      token: "token2",
+      status: "accepted",
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      created_at: new Date().toISOString(),
+    };
+    invitationRepo.addInvitation(pendingInvitation);
+    invitationRepo.addInvitation(acceptedInvitation);
+
+    const context = createMockContext({ userId, status: "pending" });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.invitations.length).toBe(1);
+    expect(data.invitations[0].status).toBe("pending");
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    const context = createMockContext({ userId: undefined });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("unauthorized");
+  });
+
+  it("should return 403 when user is not a member", async () => {
+    const context = createMockContext({ userId: otherUserId });
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("forbidden");
+    expect(data.message).toContain("do not have access");
+  });
+
+  it("should return 400 when family ID is invalid", async () => {
+    const context = {
+      params: { familyId: "invalid-id" },
+      url: new URL("http://localhost/api/invitations"),
+      locals: {
+        user: { id: userId, email: "test@example.com" },
+        repositories: {
+          family: familyRepo,
+          invitation: invitationRepo,
+          user: userRepo,
+          log: logRepo,
+        },
+      },
+    } as unknown as APIContext;
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("validation");
+  });
+
+  it("should return 400 when status is invalid", async () => {
+    const url = new URL("http://localhost/api/invitations");
+    url.searchParams.set("status", "invalid-status");
+
+    const context = {
+      params: { familyId },
+      url,
+      locals: {
+        user: { id: userId, email: "test@example.com" },
+        repositories: {
+          family: familyRepo,
+          invitation: invitationRepo,
+          user: userRepo,
+          log: logRepo,
+        },
+      },
+    } as unknown as APIContext;
+    const response = await GET(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("validation");
+  });
+});
+
+describe("POST /api/families/[familyId]/invitations", () => {
+  let familyRepo: InMemoryFamilyRepository;
+  let invitationRepo: InMemoryInvitationRepository;
+  let userRepo: InMemoryUserRepository;
+  let logRepo: InMemoryLogRepository;
+  let userId: string;
+  let familyId: string;
+  let otherUserId: string;
+
+  beforeEach(async () => {
+    const repos = createInMemoryRepositories();
+    familyRepo = repos.family as InMemoryFamilyRepository;
+    invitationRepo = repos.invitation as InMemoryInvitationRepository;
+    userRepo = repos.user as InMemoryUserRepository;
+    logRepo = repos.log as InMemoryLogRepository;
+
+    userId = "550e8400-e29b-41d4-a716-446655440001";
+    otherUserId = "550e8400-e29b-41d4-a716-446655440002";
+
+    const family = await familyRepo.create({ name: "The Smiths" });
+    familyId = family.id;
+    await familyRepo.addMember(familyId, userId, "admin");
+
+    userRepo.seed({ id: userId, full_name: "John Doe", avatar_url: null, updated_at: null }, [], "john@example.com");
+  });
+
+  function createMockContext(params: {
+    familyId?: string;
+    userId?: string;
+    body?: { invitee_email: string };
+  }): APIContext {
+    return {
+      params: { familyId: params.familyId ?? familyId },
+      request: new Request("http://localhost/api/invitations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params.body ?? { invitee_email: "alice@example.com" }),
+      }),
+      locals: {
+        user: params.userId ? { id: params.userId, email: "test@example.com" } : undefined,
+        repositories: {
+          family: familyRepo,
+          invitation: invitationRepo,
+          user: userRepo,
+          log: logRepo,
+        },
+      },
+    } as unknown as APIContext;
+  }
+
+  it("should return 201 with created invitation", async () => {
+    const context = createMockContext({ userId });
+    const response = await POST(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data).toHaveProperty("id");
+    expect(data).toHaveProperty("family_id");
+    expect(data).toHaveProperty("invited_by");
+    expect(data).toHaveProperty("invitee_email");
+    expect(data).toHaveProperty("token");
+    expect(data).toHaveProperty("status");
+    expect(data).toHaveProperty("expires_at");
+    expect(data).toHaveProperty("created_at");
+    expect(data).toHaveProperty("invitation_url");
+    expect(data.invitee_email).toBe("alice@example.com");
+    expect(data.status).toBe("pending");
+    expect(data.invitation_url).toContain(data.token);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    const context = createMockContext({ userId: undefined });
+    const response = await POST(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("unauthorized");
+  });
+
+  it("should return 403 when user is not a member", async () => {
+    const context = createMockContext({ userId: otherUserId });
+    const response = await POST(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("forbidden");
+    expect(data.message).toContain("do not have access");
+  });
+
+  it("should return 400 when family ID is invalid", async () => {
+    const context = createMockContext({ familyId: "invalid-id", userId });
+    const response = await POST(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("validation");
+  });
+
+  it("should return 400 when email is invalid", async () => {
+    const context = createMockContext({
+      userId,
+      body: { invitee_email: "invalid-email" },
+    });
+    const response = await POST(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("validation");
+  });
+
+  it("should return 400 when email is missing", async () => {
+    const context = {
+      params: { familyId },
+      request: new Request("http://localhost/api/invitations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      locals: {
+        user: { id: userId, email: "test@example.com" },
+        repositories: {
+          family: familyRepo,
+          invitation: invitationRepo,
+          user: userRepo,
+          log: logRepo,
+        },
+      },
+    } as unknown as APIContext;
+    const response = await POST(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("validation");
+  });
+
+  it("should return 409 when pending invitation already exists", async () => {
+    const existingInvitation: InvitationEntity = {
+      id: crypto.randomUUID(),
+      family_id: familyId,
+      invited_by: userId,
+      invitee_email: "alice@example.com",
+      token: "existing-token",
+      status: "pending",
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      created_at: new Date().toISOString(),
+    };
+    invitationRepo.addInvitation(existingInvitation);
+
+    const context = createMockContext({
+      userId,
+      body: { invitee_email: "alice@example.com" },
+    });
+    const response = await POST(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("conflict");
+    expect(data.message).toContain("pending invitation already exists");
+  });
+
+  it("should return 400 when user already a member", async () => {
+    const existingUser = await userRepo.create({
+      id: "550e8400-e29b-41d4-a716-446655440003",
+      full_name: "Alice",
+    });
+    userRepo.seed(existingUser, [], "alice@example.com");
+    await familyRepo.addMember(familyId, existingUser.id, "member");
+
+    const context = createMockContext({
+      userId,
+      body: { invitee_email: "alice@example.com" },
+    });
+    const response = await POST(context);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toBe("validation");
+    expect(data.message).toContain("already a member");
+  });
+});

--- a/src/pages/api/families/[familyId]/invitations/index.ts
+++ b/src/pages/api/families/[familyId]/invitations/index.ts
@@ -1,0 +1,61 @@
+import type { APIContext } from "astro";
+import { InvitationService } from "@/services/InvitationService";
+import { mapResultToResponse } from "@/lib/http/responseMapper";
+import { handleApiRequest } from "@/lib/http/apiHelpers";
+import {
+  familyIdParamPathSchema,
+  createInvitationCommandSchema,
+  listInvitationsQuerySchema,
+  type FamilyIdParamPath,
+  type CreateInvitationCommand,
+  type ListInvitationsQuery,
+} from "@/types";
+
+export const prerender = false;
+
+export async function GET({ params, url, locals }: APIContext): Promise<Response> {
+  return handleApiRequest<FamilyIdParamPath, ListInvitationsQuery>({
+    handler: async ({ userId, path, query, locals }) => {
+      const invitationService = new InvitationService(
+        locals.repositories.invitation,
+        locals.repositories.family,
+        locals.repositories.user,
+        locals.repositories.log
+      );
+
+      const result = await invitationService.listInvitations(path.familyId, userId, query?.status);
+
+      return mapResultToResponse(result);
+    },
+    context: "GET /api/families/[familyId]/invitations",
+    pathSchema: familyIdParamPathSchema,
+    querySchema: listInvitationsQuerySchema,
+    params,
+    url,
+    locals,
+  });
+}
+
+export async function POST({ params, request, locals }: APIContext): Promise<Response> {
+  return handleApiRequest<FamilyIdParamPath, unknown, CreateInvitationCommand>({
+    handler: async ({ userId, path, body, locals }) => {
+      const invitationService = new InvitationService(
+        locals.repositories.invitation,
+        locals.repositories.family,
+        locals.repositories.user,
+        locals.repositories.log
+      );
+
+      const result = await invitationService.createInvitation(path.familyId, body, userId);
+
+      return mapResultToResponse(result, { successStatus: 201 });
+    },
+    context: "POST /api/families/[familyId]/invitations",
+    pathSchema: familyIdParamPathSchema,
+    bodySchema: createInvitationCommandSchema,
+    params,
+    request,
+    locals,
+  });
+}
+

--- a/src/repositories/factory.ts
+++ b/src/repositories/factory.ts
@@ -6,12 +6,14 @@ import { SQLEventRepository } from "./implementations/sql/SQLEventRepository.ts"
 import { SQLUserRepository } from "./implementations/sql/SQLUserRepository.ts";
 import { SQLChildRepository } from "./implementations/sql/SQLChildRepository.ts";
 import { SQLLogRepository } from "./implementations/sql/SQLLogRepository.ts";
+import { SQLInvitationRepository } from "./implementations/sql/SQLInvitationRepository.ts";
 
 import { InMemoryFamilyRepository } from "./implementations/in-memory/InMemoryFamilyRepository.ts";
 import { InMemoryEventRepository } from "./implementations/in-memory/InMemoryEventRepository.ts";
 import { InMemoryUserRepository } from "./implementations/in-memory/InMemoryUserRepository.ts";
 import { InMemoryChildRepository } from "./implementations/in-memory/InMemoryChildRepository.ts";
 import { InMemoryLogRepository } from "./implementations/in-memory/InMemoryLogRepository.ts";
+import { InMemoryInvitationRepository } from "./implementations/in-memory/InMemoryInvitationRepository.ts";
 
 import type {
   FamilyRepository,
@@ -19,6 +21,7 @@ import type {
   UserRepository,
   ChildRepository,
   LogRepository,
+  InvitationRepository,
 } from "./interfaces/index.ts";
 
 export type Repositories = {
@@ -27,6 +30,7 @@ export type Repositories = {
   user: UserRepository;
   child: ChildRepository;
   log: LogRepository;
+  invitation: InvitationRepository;
 };
 
 export function createSQLRepositories(supabase: SupabaseClient<Database>): Repositories {
@@ -36,6 +40,7 @@ export function createSQLRepositories(supabase: SupabaseClient<Database>): Repos
     user: new SQLUserRepository(supabase),
     child: new SQLChildRepository(supabase),
     log: new SQLLogRepository(supabase),
+    invitation: new SQLInvitationRepository(supabase),
   };
 }
 
@@ -46,6 +51,7 @@ export function createInMemoryRepositories(): Repositories {
     user: new InMemoryUserRepository(),
     child: new InMemoryChildRepository(),
     log: new InMemoryLogRepository(),
+    invitation: new InMemoryInvitationRepository(),
   };
 }
 

--- a/src/repositories/implementations/in-memory/InMemoryInvitationRepository.ts
+++ b/src/repositories/implementations/in-memory/InMemoryInvitationRepository.ts
@@ -1,0 +1,87 @@
+import type { InvitationRepository } from "../../interfaces/InvitationRepository.ts";
+import type { InvitationEntity, InvitationInsert, InvitationUpdate, InvitationStatus } from "@/types";
+
+export class InMemoryInvitationRepository implements InvitationRepository {
+  private invitations: Map<string, InvitationEntity> = new Map();
+
+  async findById(id: string): Promise<InvitationEntity | null> {
+    return this.invitations.get(id) ?? null;
+  }
+
+  async findByFamilyId(familyId: string, status?: InvitationStatus): Promise<InvitationEntity[]> {
+    let invitations = Array.from(this.invitations.values()).filter(
+      (invitation) => invitation.family_id === familyId
+    );
+
+    if (status) {
+      invitations = invitations.filter((invitation) => invitation.status === status);
+    }
+
+    return invitations.sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+  }
+
+  async findPendingByEmailAndFamily(email: string, familyId: string): Promise<InvitationEntity | null> {
+    const invitation = Array.from(this.invitations.values()).find(
+      (inv) =>
+        inv.invitee_email === email && inv.family_id === familyId && inv.status === "pending"
+    );
+
+    return invitation ?? null;
+  }
+
+  async findByToken(token: string): Promise<InvitationEntity | null> {
+    const invitation = Array.from(this.invitations.values()).find((inv) => inv.token === token);
+    return invitation ?? null;
+  }
+
+  async create(data: InvitationInsert): Promise<InvitationEntity> {
+    const invitation: InvitationEntity = {
+      id: data.id ?? crypto.randomUUID(),
+      family_id: data.family_id,
+      invited_by: data.invited_by,
+      invitee_email: data.invitee_email,
+      token: data.token,
+      status: data.status ?? "pending",
+      expires_at: data.expires_at,
+      created_at: data.created_at ?? new Date().toISOString(),
+    };
+
+    this.invitations.set(invitation.id, invitation);
+    return invitation;
+  }
+
+  async update(id: string, data: InvitationUpdate): Promise<InvitationEntity> {
+    const invitation = this.invitations.get(id);
+    if (!invitation) {
+      throw new Error(`Invitation with id ${id} not found`);
+    }
+
+    const updated: InvitationEntity = {
+      ...invitation,
+      ...(data.family_id !== undefined && { family_id: data.family_id }),
+      ...(data.invited_by !== undefined && { invited_by: data.invited_by }),
+      ...(data.invitee_email !== undefined && { invitee_email: data.invitee_email }),
+      ...(data.token !== undefined && { token: data.token }),
+      ...(data.status !== undefined && { status: data.status }),
+      ...(data.expires_at !== undefined && { expires_at: data.expires_at }),
+    };
+
+    this.invitations.set(id, updated);
+    return updated;
+  }
+
+  async delete(id: string): Promise<void> {
+    const exists = this.invitations.has(id);
+    if (!exists) {
+      throw new Error(`Invitation with id ${id} not found`);
+    }
+    this.invitations.delete(id);
+  }
+
+  addInvitation(invitation: InvitationEntity): void {
+    this.invitations.set(invitation.id, invitation);
+  }
+}
+

--- a/src/repositories/implementations/in-memory/InMemoryUserRepository.ts
+++ b/src/repositories/implementations/in-memory/InMemoryUserRepository.ts
@@ -4,9 +4,18 @@ import type { UserFamilyMembershipDTO } from "@/types";
 export class InMemoryUserRepository implements UserRepository {
   private users: Map<string, User> = new Map();
   private memberships: Map<string, UserFamilyMembershipDTO[]> = new Map();
+  private emailToUserId: Map<string, string> = new Map();
 
   async findById(id: string): Promise<User | null> {
     return this.users.get(id) ?? null;
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const userId = this.emailToUserId.get(email.toLowerCase());
+    if (!userId) {
+      return null;
+    }
+    return this.users.get(userId) ?? null;
   }
 
   async create(data: CreateUserDTO): Promise<User> {
@@ -44,9 +53,12 @@ export class InMemoryUserRepository implements UserRepository {
     return this.memberships.get(userId) || [];
   }
 
-  seed(user: User, memberships: UserFamilyMembershipDTO[] = []): void {
+  seed(user: User, memberships: UserFamilyMembershipDTO[] = [], email?: string): void {
     this.users.set(user.id, user);
     this.memberships.set(user.id, memberships);
+    if (email) {
+      this.emailToUserId.set(email.toLowerCase(), user.id);
+    }
   }
 
   clear(): void {

--- a/src/repositories/implementations/sql/SQLInvitationRepository.ts
+++ b/src/repositories/implementations/sql/SQLInvitationRepository.ts
@@ -1,0 +1,128 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../../../db/database.types.ts";
+import type { InvitationRepository } from "../../interfaces/InvitationRepository.ts";
+import type { InvitationEntity, InvitationInsert, InvitationUpdate, InvitationStatus } from "@/types";
+
+export class SQLInvitationRepository implements InvitationRepository {
+  constructor(private readonly supabase: SupabaseClient<Database>) {}
+
+  async findById(id: string): Promise<InvitationEntity | null> {
+    const { data, error } = await this.supabase.from("invitations").select("*").eq("id", id).single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return this.mapToDomain(data);
+  }
+
+  async findByFamilyId(familyId: string, status?: InvitationStatus): Promise<InvitationEntity[]> {
+    let query = this.supabase.from("invitations").select("*").eq("family_id", familyId);
+
+    if (status) {
+      query = query.eq("status", status);
+    }
+
+    query = query.order("created_at", { ascending: false });
+
+    const { data, error } = await query;
+
+    if (error || !data) {
+      return [];
+    }
+
+    return data.map((row) => this.mapToDomain(row));
+  }
+
+  async findPendingByEmailAndFamily(email: string, familyId: string): Promise<InvitationEntity | null> {
+    const { data, error } = await this.supabase
+      .from("invitations")
+      .select("*")
+      .eq("invitee_email", email)
+      .eq("family_id", familyId)
+      .eq("status", "pending")
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return this.mapToDomain(data);
+  }
+
+  async findByToken(token: string): Promise<InvitationEntity | null> {
+    const { data, error } = await this.supabase.from("invitations").select("*").eq("token", token).single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return this.mapToDomain(data);
+  }
+
+  async create(data: InvitationInsert): Promise<InvitationEntity> {
+    const { data: result, error } = await this.supabase
+      .from("invitations")
+      .insert({
+        family_id: data.family_id,
+        invited_by: data.invited_by,
+        invitee_email: data.invitee_email,
+        token: data.token,
+        status: data.status ?? "pending",
+        expires_at: data.expires_at,
+      })
+      .select()
+      .single();
+
+    if (error || !result) {
+      throw new Error(`Failed to create invitation: ${error?.message ?? "Unknown error"}`);
+    }
+
+    return this.mapToDomain(result);
+  }
+
+  async update(id: string, data: InvitationUpdate): Promise<InvitationEntity> {
+    const updateData: Partial<Database["public"]["Tables"]["invitations"]["Update"]> = {};
+    if (data.family_id !== undefined) updateData.family_id = data.family_id;
+    if (data.invited_by !== undefined) updateData.invited_by = data.invited_by;
+    if (data.invitee_email !== undefined) updateData.invitee_email = data.invitee_email;
+    if (data.token !== undefined) updateData.token = data.token;
+    if (data.status !== undefined) updateData.status = data.status;
+    if (data.expires_at !== undefined) updateData.expires_at = data.expires_at;
+
+    const { data: result, error } = await this.supabase
+      .from("invitations")
+      .update(updateData)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error || !result) {
+      throw new Error(`Failed to update invitation: ${error?.message ?? "Unknown error"}`);
+    }
+
+    return this.mapToDomain(result);
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.supabase.from("invitations").delete().eq("id", id);
+
+    if (error) {
+      throw new Error(`Failed to delete invitation: ${error.message}`);
+    }
+  }
+
+  private mapToDomain(row: Database["public"]["Tables"]["invitations"]["Row"]): InvitationEntity {
+    return {
+      id: row.id,
+      family_id: row.family_id,
+      invited_by: row.invited_by,
+      invitee_email: row.invitee_email,
+      token: row.token,
+      status: row.status,
+      expires_at: row.expires_at,
+      created_at: row.created_at,
+    };
+  }
+}
+

--- a/src/repositories/implementations/sql/SQLUserRepository.ts
+++ b/src/repositories/implementations/sql/SQLUserRepository.ts
@@ -16,6 +16,25 @@ export class SQLUserRepository implements UserRepository {
     return this.mapToDomain(data);
   }
 
+  async findByEmail(email: string): Promise<User | null> {
+    try {
+      const { data: users, error } = await this.supabase.auth.admin.listUsers();
+      if (error || !users) {
+        return null;
+      }
+
+      const authUser = users.users.find((user) => user.email === email);
+      if (!authUser) {
+        return null;
+      }
+
+      return this.findById(authUser.id);
+    } catch (error) {
+      console.error("Error finding user by email:", error);
+      return null;
+    }
+  }
+
   async create(data: CreateUserDTO): Promise<User> {
     const { data: result, error } = await this.supabase
       .from("users")

--- a/src/repositories/interfaces/InvitationRepository.ts
+++ b/src/repositories/interfaces/InvitationRepository.ts
@@ -1,0 +1,13 @@
+import type { InvitationStatus } from "@/types";
+import type { InvitationEntity, InvitationInsert, InvitationUpdate } from "@/types";
+
+export interface InvitationRepository {
+  findById(id: string): Promise<InvitationEntity | null>;
+  findByFamilyId(familyId: string, status?: InvitationStatus): Promise<InvitationEntity[]>;
+  findPendingByEmailAndFamily(email: string, familyId: string): Promise<InvitationEntity | null>;
+  findByToken(token: string): Promise<InvitationEntity | null>;
+  create(data: InvitationInsert): Promise<InvitationEntity>;
+  update(id: string, data: InvitationUpdate): Promise<InvitationEntity>;
+  delete(id: string): Promise<void>;
+}
+

--- a/src/repositories/interfaces/UserRepository.ts
+++ b/src/repositories/interfaces/UserRepository.ts
@@ -20,6 +20,7 @@ export interface UpdateUserDTO {
 
 export interface UserRepository {
   findById(id: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
   create(data: CreateUserDTO): Promise<User>;
   update(id: string, data: UpdateUserDTO): Promise<User>;
   delete(id: string): Promise<void>;

--- a/src/repositories/interfaces/index.ts
+++ b/src/repositories/interfaces/index.ts
@@ -29,3 +29,5 @@ export type {
 
 export type { LogInsert, LogRepository } from "./LogRepository.ts";
 
+export type { InvitationRepository } from "./InvitationRepository.ts";
+

--- a/src/services/InvitationService.test.ts
+++ b/src/services/InvitationService.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { InvitationService } from "./InvitationService";
+import { InMemoryInvitationRepository } from "@/repositories/implementations/in-memory/InMemoryInvitationRepository";
+import { InMemoryFamilyRepository } from "@/repositories/implementations/in-memory/InMemoryFamilyRepository";
+import { InMemoryUserRepository } from "@/repositories/implementations/in-memory/InMemoryUserRepository";
+import { InMemoryLogRepository } from "@/repositories/implementations/in-memory/InMemoryLogRepository";
+import {
+  ValidationError,
+  NotFoundError,
+  ForbiddenError,
+  ConflictError,
+  DomainError,
+} from "@/domain/errors";
+import type { InvitationEntity } from "@/types";
+
+describe("InvitationService", () => {
+  let invitationService: InvitationService;
+  let invitationRepo: InMemoryInvitationRepository;
+  let familyRepo: InMemoryFamilyRepository;
+  let userRepo: InMemoryUserRepository;
+  let logRepo: InMemoryLogRepository;
+  let userId: string;
+  let familyId: string;
+  let otherUserId: string;
+
+  beforeEach(async () => {
+    invitationRepo = new InMemoryInvitationRepository();
+    familyRepo = new InMemoryFamilyRepository();
+    userRepo = new InMemoryUserRepository();
+    logRepo = new InMemoryLogRepository();
+
+    invitationService = new InvitationService(
+      invitationRepo,
+      familyRepo,
+      userRepo,
+      logRepo
+    );
+
+    userId = "550e8400-e29b-41d4-a716-446655440001";
+    otherUserId = "550e8400-e29b-41d4-a716-446655440002";
+
+    const family = await familyRepo.create({ name: "The Smiths" });
+    familyId = family.id;
+    await familyRepo.addMember(familyId, userId, "admin");
+
+    userRepo.seed(
+      { id: userId, full_name: "John Doe", avatar_url: null, updated_at: null },
+      [],
+      "john@example.com"
+    );
+  });
+
+  describe("listInvitations", () => {
+    it("should return invitations for a family member", async () => {
+      const invitation1: InvitationEntity = {
+        id: crypto.randomUUID(),
+        family_id: familyId,
+        invited_by: userId,
+        invitee_email: "alice@example.com",
+        token: "token1",
+        status: "pending",
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        created_at: new Date().toISOString(),
+      };
+      invitationRepo.addInvitation(invitation1);
+
+      const result = await invitationService.listInvitations(familyId, userId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.invitations).toHaveLength(1);
+        expect(result.data.invitations[0].id).toBe(invitation1.id);
+        expect(result.data.invitations[0].invitee_email).toBe("alice@example.com");
+        expect(result.data.invitations[0].invited_by.id).toBe(userId);
+        expect(result.data.invitations[0].invited_by.full_name).toBe("John Doe");
+      }
+    });
+
+    it("should filter invitations by status", async () => {
+      const pendingInvitation: InvitationEntity = {
+        id: crypto.randomUUID(),
+        family_id: familyId,
+        invited_by: userId,
+        invitee_email: "alice@example.com",
+        token: "token1",
+        status: "pending",
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        created_at: new Date().toISOString(),
+      };
+      const acceptedInvitation: InvitationEntity = {
+        id: crypto.randomUUID(),
+        family_id: familyId,
+        invited_by: userId,
+        invitee_email: "bob@example.com",
+        token: "token2",
+        status: "accepted",
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        created_at: new Date().toISOString(),
+      };
+      invitationRepo.addInvitation(pendingInvitation);
+      invitationRepo.addInvitation(acceptedInvitation);
+
+      const result = await invitationService.listInvitations(familyId, userId, "pending");
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.invitations).toHaveLength(1);
+        expect(result.data.invitations[0].status).toBe("pending");
+      }
+    });
+
+    it("should return error if family ID is invalid UUID", async () => {
+      const result = await invitationService.listInvitations("invalid-id", userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toContain("Invalid family ID format");
+      }
+    });
+
+    it("should return error if family not found", async () => {
+      const fakeId = "550e8400-e29b-41d4-a716-446655440000";
+      const result = await invitationService.listInvitations(fakeId, userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(NotFoundError);
+      }
+    });
+
+    it("should return error if user is not a member", async () => {
+      const result = await invitationService.listInvitations(familyId, otherUserId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ForbiddenError);
+        expect(result.error.message).toContain("do not have access");
+      }
+    });
+  });
+
+  describe("createInvitation", () => {
+    it("should create an invitation successfully", async () => {
+      const command = { invitee_email: "alice@example.com" };
+      const result = await invitationService.createInvitation(familyId, command, userId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.invitee_email).toBe("alice@example.com");
+        expect(result.data.family_id).toBe(familyId);
+        expect(result.data.invited_by).toBe(userId);
+        expect(result.data.status).toBe("pending");
+        expect(result.data.token).toBeDefined();
+        expect(result.data.token.length).toBeGreaterThan(0);
+        expect(result.data.invitation_url).toBeDefined();
+        expect(result.data.invitation_url).toContain(result.data.token);
+        expect(result.data.expires_at).toBeDefined();
+
+        const expiresAt = new Date(result.data.expires_at);
+        const now = new Date();
+        const sevenDaysFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+        expect(expiresAt.getTime()).toBeCloseTo(sevenDaysFromNow.getTime(), -3);
+      }
+    });
+
+    it("should return error if family ID is invalid UUID", async () => {
+      const command = { invitee_email: "alice@example.com" };
+      const result = await invitationService.createInvitation("invalid-id", command, userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toContain("Invalid family ID format");
+      }
+    });
+
+    it("should return error if email is invalid", async () => {
+      const command = { invitee_email: "invalid-email" };
+      const result = await invitationService.createInvitation(familyId, command, userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+      }
+    });
+
+    it("should return error if family not found", async () => {
+      const fakeId = "550e8400-e29b-41d4-a716-446655440000";
+      const command = { invitee_email: "alice@example.com" };
+      const result = await invitationService.createInvitation(fakeId, command, userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(NotFoundError);
+      }
+    });
+
+    it("should return error if user is not a member", async () => {
+      const command = { invitee_email: "alice@example.com" };
+      const result = await invitationService.createInvitation(familyId, command, otherUserId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ForbiddenError);
+        expect(result.error.message).toContain("do not have access");
+      }
+    });
+
+    it("should return error if user already a member", async () => {
+      const existingUser = await userRepo.create({
+        id: "550e8400-e29b-41d4-a716-446655440003",
+        full_name: "Alice",
+      });
+      userRepo.seed(existingUser, [], "alice@example.com");
+      await familyRepo.addMember(familyId, existingUser.id, "member");
+
+      const command = { invitee_email: "alice@example.com" };
+      const result = await invitationService.createInvitation(familyId, command, userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toContain("already a member");
+      }
+    });
+
+    it("should return error if pending invitation already exists", async () => {
+      const existingInvitation: InvitationEntity = {
+        id: crypto.randomUUID(),
+        family_id: familyId,
+        invited_by: userId,
+        invitee_email: "alice@example.com",
+        token: "existing-token",
+        status: "pending",
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        created_at: new Date().toISOString(),
+      };
+      invitationRepo.addInvitation(existingInvitation);
+
+      const command = { invitee_email: "alice@example.com" };
+      const result = await invitationService.createInvitation(familyId, command, userId);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ConflictError);
+        expect(result.error.message).toContain("pending invitation already exists");
+      }
+    });
+
+    it("should allow creating invitation if previous invitation was accepted", async () => {
+      const acceptedInvitation: InvitationEntity = {
+        id: crypto.randomUUID(),
+        family_id: familyId,
+        invited_by: userId,
+        invitee_email: "alice@example.com",
+        token: "accepted-token",
+        status: "accepted",
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        created_at: new Date().toISOString(),
+      };
+      invitationRepo.addInvitation(acceptedInvitation);
+
+      const command = { invitee_email: "alice@example.com" };
+      const result = await invitationService.createInvitation(familyId, command, userId);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should create audit log entry", async () => {
+      const command = { invitee_email: "alice@example.com" };
+      const result = await invitationService.createInvitation(familyId, command, userId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const logs = logRepo.getLogs();
+        const invitationLog = logs.find((log) => log.action === "invitation.create");
+        expect(invitationLog).toBeDefined();
+        expect(invitationLog?.actor_id).toBe(userId);
+        expect(invitationLog?.actor_type).toBe("user");
+        expect(invitationLog?.family_id).toBe(familyId);
+      }
+    });
+  });
+});
+

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -1,0 +1,187 @@
+import type { Result } from "@/domain/result";
+import { ok, err } from "@/domain/result";
+import {
+  NotFoundError,
+  ValidationError,
+  ForbiddenError,
+  ConflictError,
+  DomainError,
+  InternalError,
+} from "@/domain/errors";
+import type { InvitationRepository } from "@/repositories/interfaces/InvitationRepository";
+import type { FamilyRepository } from "@/repositories/interfaces/FamilyRepository";
+import type { UserRepository } from "@/repositories/interfaces/UserRepository";
+import type { LogRepository } from "@/repositories/interfaces/LogRepository";
+import { uuidSchema, invitationStatusSchema, createInvitationCommandSchema, validateSchema } from "@/types";
+import type {
+  CreateInvitationCommand,
+  CreateInvitationResponseDTO,
+  ListInvitationsResponseDTO,
+  InvitationWithInviterDTO,
+  InvitationStatus,
+} from "@/types";
+import type { z } from "zod";
+import { generateSecureToken } from "@/lib/utils/token";
+import { buildInvitationUrl } from "@/lib/utils/invitation";
+
+export class InvitationService {
+  constructor(
+    private readonly invitationRepo: InvitationRepository,
+    private readonly familyRepo: FamilyRepository,
+    private readonly userRepo: UserRepository,
+    private readonly logRepo: LogRepository
+  ) {}
+
+  async listInvitations(
+    familyId: string,
+    userId: string,
+    status?: InvitationStatus
+  ): Promise<Result<ListInvitationsResponseDTO, DomainError>> {
+    const uuidValidation = uuidSchema.safeParse(familyId);
+    if (!uuidValidation.success) {
+      return err(new ValidationError("Invalid family ID format"));
+    }
+
+    const family = await this.familyRepo.findById(familyId);
+    if (!family) {
+      return err(new NotFoundError("Family", familyId));
+    }
+
+    const isMember = await this.familyRepo.isUserMember(familyId, userId);
+    if (!isMember) {
+      return err(new ForbiddenError("You do not have access to this family"));
+    }
+
+    try {
+      const invitations = await this.invitationRepo.findByFamilyId(familyId, status);
+
+      const invitationsWithInviter: InvitationWithInviterDTO[] = await Promise.all(
+        invitations.map(async (invitation) => {
+          const inviter = await this.userRepo.findById(invitation.invited_by);
+          return {
+            id: invitation.id,
+            family_id: invitation.family_id,
+            invited_by: {
+              id: invitation.invited_by,
+              full_name: inviter?.full_name ?? null,
+            },
+            invitee_email: invitation.invitee_email,
+            status: invitation.status,
+            expires_at: invitation.expires_at,
+            created_at: invitation.created_at,
+          };
+        })
+      );
+
+      return ok({
+        invitations: invitationsWithInviter,
+      });
+    } catch (error) {
+      console.error("Error in InvitationService.listInvitations:", error);
+      return err(new InternalError("Failed to retrieve invitations"));
+    }
+  }
+
+  async createInvitation(
+    familyId: string,
+    command: CreateInvitationCommand,
+    userId: string
+  ): Promise<Result<CreateInvitationResponseDTO, DomainError>> {
+    const uuidValidation = uuidSchema.safeParse(familyId);
+    if (!uuidValidation.success) {
+      return err(new ValidationError("Invalid family ID format"));
+    }
+
+    const validationResult = validateSchema(createInvitationCommandSchema, command);
+    if (!validationResult.success) {
+      const fieldErrors: Record<string, string> = {};
+      validationResult.error.issues.forEach((issue: z.ZodIssue) => {
+        const path = issue.path.join(".");
+        fieldErrors[path] = issue.message;
+      });
+      const firstError = validationResult.error.issues[0];
+      const errorMessage = firstError ? firstError.message : "Invalid email format";
+      return err(new ValidationError(errorMessage, fieldErrors));
+    }
+
+    const family = await this.familyRepo.findById(familyId);
+    if (!family) {
+      return err(new NotFoundError("Family", familyId));
+    }
+
+    const isMember = await this.familyRepo.isUserMember(familyId, userId);
+    if (!isMember) {
+      return err(new ForbiddenError("You do not have access to this family"));
+    }
+
+    const existingUser = await this.userRepo.findByEmail(validationResult.data.invitee_email);
+    if (existingUser) {
+      const isAlreadyMember = await this.familyRepo.isUserMember(familyId, existingUser.id);
+      if (isAlreadyMember) {
+        return err(
+          new ValidationError("User with this email is already a member of this family", {
+            invitee_email: "already_member",
+          })
+        );
+      }
+    }
+
+    const pendingInvitation = await this.invitationRepo.findPendingByEmailAndFamily(
+      validationResult.data.invitee_email,
+      familyId
+    );
+    if (pendingInvitation) {
+      return err(new ConflictError("A pending invitation already exists for this email"));
+    }
+
+    try {
+      const token = generateSecureToken();
+      const expiresAt = new Date();
+      expiresAt.setDate(expiresAt.getDate() + 7);
+
+      const invitation = await this.invitationRepo.create({
+        family_id: familyId,
+        invited_by: userId,
+        invitee_email: validationResult.data.invitee_email,
+        token,
+        status: "pending",
+        expires_at: expiresAt.toISOString(),
+      });
+
+      const invitationUrl = buildInvitationUrl(token);
+
+      const response: CreateInvitationResponseDTO = {
+        id: invitation.id,
+        family_id: invitation.family_id,
+        invited_by: invitation.invited_by,
+        invitee_email: invitation.invitee_email,
+        token: invitation.token,
+        status: invitation.status,
+        expires_at: invitation.expires_at,
+        created_at: invitation.created_at,
+        invitation_url: invitationUrl,
+      };
+
+      this.logRepo
+        .create({
+          family_id: familyId,
+          actor_id: userId,
+          actor_type: "user",
+          action: "invitation.create",
+          details: {
+            invitation_id: invitation.id,
+            invitee_email: invitation.invitee_email,
+            family_id: familyId,
+          },
+        })
+        .catch((error) => {
+          console.error("Failed to log invitation.create:", error);
+        });
+
+      return ok(response);
+    } catch (error) {
+      console.error("Error in InvitationService.createInvitation:", error);
+      return err(new InternalError("Failed to create invitation"));
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1104,3 +1104,9 @@ export const childIdPathSchema = z.object({
 });
 
 export type ChildIdPath = z.infer<typeof childIdPathSchema>;
+
+export const listInvitationsQuerySchema = z.object({
+  status: invitationStatusSchema.optional(),
+});
+
+export type ListInvitationsQuery = z.infer<typeof listInvitationsQuerySchema>;


### PR DESCRIPTION
- Add InvitationRepository interface and implementations (SQL and In-Memory)
- Implement InvitationService with listInvitations and createInvitation methods
- Create GET and POST endpoints for /api/families/{familyId}/invitations
- Add secure token generation and invitation URL building utilities
- Add findByEmail method to UserRepository
- Implement comprehensive validation and error handling
- Add audit logging for invitation creation
- Include full test coverage (28 tests) for service and API layers
- Support optional status filtering for listing invitations
- Prevent duplicate pending invitations and existing member invitations