### PR TITLE
onboarding hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@astrojs/sitemap": "^3.5.1",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -767,6 +770,19 @@ packages:
 
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4924,6 +4940,20 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.2.0)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:

--- a/src/pages/api/families/[familyId]/members.ts
+++ b/src/pages/api/families/[familyId]/members.ts
@@ -13,7 +13,8 @@ export async function GET({ params, locals }: APIContext): Promise<Response> {
       const familyService = new FamilyService(
         locals.repositories.family,
         locals.repositories.child,
-        locals.repositories.log
+        locals.repositories.log,
+        locals.repositories.user
       );
       const result = await familyService.getFamilyMembers(path.familyId, userId);
 

--- a/src/pages/api/families/[id].ts
+++ b/src/pages/api/families/[id].ts
@@ -17,7 +17,8 @@ export async function GET({ params, locals }: APIContext): Promise<Response> {
       const familyService = new FamilyService(
         locals.repositories.family,
         locals.repositories.child,
-        locals.repositories.log
+        locals.repositories.log,
+        locals.repositories.user
       );
       const result = await familyService.getFamilyDetails(path.id, userId);
       return mapResultToResponse(result);
@@ -35,7 +36,8 @@ export async function PATCH({ params, request, locals }: APIContext): Promise<Re
       const familyService = new FamilyService(
         locals.repositories.family,
         locals.repositories.child,
-        locals.repositories.log
+        locals.repositories.log,
+        locals.repositories.user
       );
       const result = await familyService.updateFamily(path.id, body, userId);
       return mapResultToResponse(result);
@@ -55,7 +57,8 @@ export async function DELETE({ params, locals }: APIContext): Promise<Response> 
       const familyService = new FamilyService(
         locals.repositories.family,
         locals.repositories.child,
-        locals.repositories.log
+        locals.repositories.log,
+        locals.repositories.user
       );
       const result = await familyService.deleteFamily(path.id, userId);
       return mapResultToResponse(result, { successStatus: 204 });

--- a/src/pages/api/families/index.ts
+++ b/src/pages/api/families/index.ts
@@ -12,7 +12,8 @@ export async function POST({ request, locals }: APIContext): Promise<Response> {
       const familyService = new FamilyService(
         locals.repositories.family,
         locals.repositories.child,
-        locals.repositories.log
+        locals.repositories.log,
+        locals.repositories.user
       );
       const result = await familyService.createFamily(body, userId);
       return mapResultToResponse(result, { successStatus: 201 });
@@ -23,4 +24,3 @@ export async function POST({ request, locals }: APIContext): Promise<Response> {
     locals,
   });
 }
-

--- a/supabase/migrations/20260113000000_fix_families_select_policy.sql
+++ b/supabase/migrations/20260113000000_fix_families_select_policy.sql
@@ -1,0 +1,18 @@
+-- Fix families SELECT policy to allow viewing just-created families
+-- This allows users to see families immediately after creation, before being added as a member
+
+-- Drop the existing restrictive SELECT policy
+DROP POLICY IF EXISTS families_select ON public.families;
+
+-- Create a new SELECT policy that allows:
+-- 1. Viewing families where the user is a member (original behavior)
+-- 2. Viewing families created in the last 10 seconds (for the creation flow)
+CREATE POLICY families_select
+  ON public.families
+  FOR SELECT
+  TO authenticated
+  USING (
+    is_family_member(id) 
+    OR 
+    (created_at > (NOW() - INTERVAL '10 seconds'))
+  );

--- a/supabase/migrations/20260113000001_fix_family_members_insert_policy.sql
+++ b/supabase/migrations/20260113000001_fix_family_members_insert_policy.sql
@@ -1,0 +1,27 @@
+-- Fix family_members INSERT policy to allow adding yourself to newly created families
+-- This solves the chicken-and-egg problem where you need to be an admin to add members,
+-- but you can't be an admin until you're added as a member
+
+-- Drop the existing restrictive INSERT policy
+DROP POLICY IF EXISTS family_members_insert ON public.family_members;
+
+-- Create a new INSERT policy that allows:
+-- 1. Admins to add any member (original behavior)
+-- 2. Any authenticated user to add themselves to a family created in the last 10 seconds
+CREATE POLICY family_members_insert
+  ON public.family_members
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    is_family_admin(family_id)
+    OR
+    (
+      user_id = auth.uid()
+      AND
+      EXISTS (
+        SELECT 1 FROM public.families
+        WHERE id = family_id
+        AND created_at > (NOW() - INTERVAL '10 seconds')
+      )
+    )
+  );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the onboarding flow so a new user can create a family, see it right away, and be added as an admin without errors. Updates API and Supabase policies to remove the RLS chicken-and-egg during family creation.

- **Bug Fixes**
  - Create a user record on first family creation, then add that user as admin and return the new family reliably.
  - API routes now pass UserRepository to FamilyService; added error logging on create failures.

- **Migration**
  - Adjust RLS: families SELECT allows viewing families created in the last 10s; family_members INSERT lets a user self-add to a just-created family.
  - Run the new Supabase migrations before deploy; no manual data changes needed.

<sup>Written for commit 1477b245b1c557e214d23ded769e487079c4cabb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

